### PR TITLE
refactor: centralized classify module for consistent molecular classification

### DIFF
--- a/pdbrust-python/examples/selection_language.py
+++ b/pdbrust-python/examples/selection_language.py
@@ -214,7 +214,7 @@ Keywords:
   backbone         - N, CA, C, O atoms
   protein          - standard amino acids
   nucleic          - standard nucleotides
-  water            - water molecules (HOH, WAT)
+  water            - water molecules (HOH, WAT, H2O, DOD, TIP, TIP3)
   hetero           - HETATM records
   hydrogen         - hydrogen atoms
   all / *          - all atoms

--- a/pdbrust-python/src/structure.rs
+++ b/pdbrust-python/src/structure.rs
@@ -324,7 +324,7 @@ impl PyPdbStructure {
     ///     - backbone: N, CA, C, O atoms
     ///     - protein: Standard amino acids
     ///     - nucleic: Standard nucleotides
-    ///     - water: Water molecules (HOH, WAT)
+    ///     - water: Water molecules (HOH, WAT, H2O, DOD, TIP, TIP3)
     ///     - hetero: HETATM records
     ///     - hydrogen: Hydrogen atoms
     ///     - all or *: All atoms

--- a/src/classify.rs
+++ b/src/classify.rs
@@ -1,0 +1,165 @@
+//! Canonical molecular classification constants and helpers.
+//!
+//! This module centralizes the definitions for identifying molecular entity types
+//! (water, protein, nucleic acid, ligand, ion) so that all other modules use
+//! consistent criteria. Import from here instead of defining local lists.
+
+use crate::records::Atom;
+
+/// Residue names recognized as water across all PDB conventions.
+pub const WATER_RESIDUES: &[&str] = &["HOH", "WAT", "H2O", "DOD", "TIP", "TIP3"];
+
+/// The 20 standard amino acid residue names (3-letter codes).
+pub const STANDARD_AMINO_ACIDS: &[&str] = &[
+    "ALA", "ARG", "ASN", "ASP", "CYS", "GLN", "GLU", "GLY", "HIS", "ILE", "LEU", "LYS", "MET",
+    "PHE", "PRO", "SER", "THR", "TRP", "TYR", "VAL",
+];
+
+/// Standard nucleotide residue names (RNA + DNA).
+pub const STANDARD_NUCLEOTIDES: &[&str] = &[
+    "A", "C", "G", "U", // RNA
+    "DA", "DC", "DG", "DT", // DNA
+];
+
+/// Common ion residue names.
+pub const COMMON_IONS: &[&str] = &[
+    "NA", "CL", "MG", "ZN", "CA", "FE", "MN", "CO", "CU", "K", "NI", "CD", "HG",
+];
+
+/// Check if a residue name is water.
+#[inline]
+pub fn is_water(residue_name: &str) -> bool {
+    let name = residue_name.trim();
+    WATER_RESIDUES.contains(&name)
+}
+
+/// Check if a residue name is a standard amino acid (the canonical 20).
+#[inline]
+pub fn is_standard_amino_acid(residue_name: &str) -> bool {
+    STANDARD_AMINO_ACIDS.contains(&residue_name.trim())
+}
+
+/// Check if a residue name is a standard nucleotide.
+#[inline]
+pub fn is_standard_nucleotide(residue_name: &str) -> bool {
+    STANDARD_NUCLEOTIDES.contains(&residue_name.trim())
+}
+
+/// Check if a residue name is a standard biological residue (amino acid or nucleotide).
+#[inline]
+pub fn is_standard_residue(residue_name: &str) -> bool {
+    is_standard_amino_acid(residue_name) || is_standard_nucleotide(residue_name)
+}
+
+/// Check if an atom is a protein atom (standard amino acid, not HETATM).
+///
+/// This uses the `is_hetatm` flag as the primary discriminator, which correctly
+/// excludes modified residues like MSE/SEP that are marked as HETATM in PDB files.
+#[inline]
+pub fn is_protein_atom(atom: &Atom) -> bool {
+    !atom.is_hetatm && is_standard_amino_acid(&atom.residue_name)
+}
+
+/// Check if an atom is a ligand atom (HETATM, not water, not ion).
+#[inline]
+pub fn is_ligand_atom(atom: &Atom) -> bool {
+    atom.is_hetatm && !is_water(&atom.residue_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_water() {
+        assert!(is_water("HOH"));
+        assert!(is_water("WAT"));
+        assert!(is_water("H2O"));
+        assert!(is_water("DOD"));
+        assert!(is_water("TIP"));
+        assert!(is_water("TIP3"));
+        assert!(!is_water("ALA"));
+        assert!(!is_water("LIG"));
+    }
+
+    #[test]
+    fn test_is_standard_amino_acid() {
+        assert!(is_standard_amino_acid("ALA"));
+        assert!(is_standard_amino_acid("GLY"));
+        assert!(is_standard_amino_acid(" ALA "));
+        assert!(!is_standard_amino_acid("HOH"));
+        assert!(!is_standard_amino_acid("ATP"));
+        // SEC and PYL are non-standard (not in the canonical 20)
+        assert!(!is_standard_amino_acid("SEC"));
+        assert!(!is_standard_amino_acid("PYL"));
+    }
+
+    #[test]
+    fn test_is_standard_nucleotide() {
+        assert!(is_standard_nucleotide("A"));
+        assert!(is_standard_nucleotide("DA"));
+        assert!(!is_standard_nucleotide("ALA"));
+    }
+
+    #[test]
+    fn test_is_standard_residue() {
+        assert!(is_standard_residue("ALA"));
+        assert!(is_standard_residue("A"));
+        assert!(!is_standard_residue("HOH"));
+    }
+
+    #[test]
+    fn test_is_protein_atom() {
+        let protein = Atom {
+            serial: 1,
+            name: "CA".to_string(),
+            alt_loc: None,
+            residue_name: "ALA".to_string(),
+            chain_id: "A".to_string(),
+            residue_seq: 1,
+            ins_code: None,
+            is_hetatm: false,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            occupancy: 1.0,
+            temp_factor: 20.0,
+            element: "C".to_string(),
+        };
+        assert!(is_protein_atom(&protein));
+
+        let hetatm = Atom {
+            is_hetatm: true,
+            residue_name: "MSE".to_string(),
+            ..protein.clone()
+        };
+        assert!(!is_protein_atom(&hetatm));
+    }
+
+    #[test]
+    fn test_is_ligand_atom() {
+        let ligand = Atom {
+            serial: 1,
+            name: "C1".to_string(),
+            alt_loc: None,
+            residue_name: "LIG".to_string(),
+            chain_id: "A".to_string(),
+            residue_seq: 100,
+            ins_code: None,
+            is_hetatm: true,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            occupancy: 1.0,
+            temp_factor: 20.0,
+            element: "C".to_string(),
+        };
+        assert!(is_ligand_atom(&ligand));
+
+        let water = Atom {
+            residue_name: "HOH".to_string(),
+            ..ligand.clone()
+        };
+        assert!(!is_ligand_atom(&water));
+    }
+}

--- a/src/descriptors/interactions.rs
+++ b/src/descriptors/interactions.rs
@@ -35,8 +35,9 @@
 //! }
 //! ```
 
-use crate::PdbStructure;
+use crate::classify::{is_standard_amino_acid, is_water};
 use crate::records::Atom;
+use crate::PdbStructure;
 use std::collections::{HashMap, HashSet};
 
 /// Type alias for residue contact tracking: (min_distance, num_contacts, residue_name)
@@ -317,7 +318,7 @@ impl PdbStructure {
         let ligand_atoms: Vec<&Atom> = self
             .atoms
             .iter()
-            .filter(|a| a.residue_name == ligand_name)
+            .filter(|a| a.is_hetatm && a.residue_name == ligand_name)
             .collect();
 
         if ligand_atoms.is_empty() {
@@ -328,11 +329,11 @@ impl PdbStructure {
         let ligand_chain = ligand_atoms[0].chain_id.clone();
         let ligand_resid = ligand_atoms[0].residue_seq;
 
-        // Find protein atoms (standard amino acids)
+        // Find protein atoms (standard amino acids, non-HETATM)
         let protein_atoms: Vec<&Atom> = self
             .atoms
             .iter()
-            .filter(|a| is_standard_amino_acid(&a.residue_name))
+            .filter(|a| !a.is_hetatm && is_standard_amino_acid(&a.residue_name))
             .collect();
 
         // Track contacts per residue
@@ -412,11 +413,11 @@ impl PdbStructure {
     /// }
     /// ```
     pub fn ligand_interactions(&self, ligand_name: &str) -> Option<LigandInteractionProfile> {
-        // Find ligand atoms
+        // Find ligand atoms (HETATM records with matching name)
         let ligand_atoms: Vec<&Atom> = self
             .atoms
             .iter()
-            .filter(|a| a.residue_name == ligand_name)
+            .filter(|a| a.is_hetatm && a.residue_name == ligand_name)
             .collect();
 
         if ligand_atoms.is_empty() {
@@ -429,11 +430,11 @@ impl PdbStructure {
         // Get binding site first
         let binding_site = self.binding_site(ligand_name, 6.0)?;
 
-        // Find protein atoms
+        // Find protein atoms (standard amino acids, non-HETATM)
         let protein_atoms: Vec<&Atom> = self
             .atoms
             .iter()
-            .filter(|a| is_standard_amino_acid(&a.residue_name))
+            .filter(|a| !a.is_hetatm && is_standard_amino_acid(&a.residue_name))
             .collect();
 
         let mut hydrogen_bonds = Vec::new();
@@ -541,12 +542,11 @@ impl PdbStructure {
     /// }
     /// ```
     pub fn all_ligand_interactions(&self) -> Vec<LigandInteractionProfile> {
-        // Find unique ligand names (excluding water)
+        // Find unique ligand names (HETATM, excluding water)
         let ligand_names: HashSet<String> = self
             .atoms
             .iter()
-            .filter(|a| !is_standard_amino_acid(&a.residue_name))
-            .filter(|a| !["HOH", "WAT", "H2O", "DOD"].contains(&a.residue_name.as_str()))
+            .filter(|a| a.is_hetatm && !is_water(&a.residue_name))
             .map(|a| a.residue_name.clone())
             .collect();
 
@@ -556,15 +556,6 @@ impl PdbStructure {
             .filter(|profile| !profile.contact_residues.is_empty())
             .collect()
     }
-}
-
-/// Check if a residue name is a standard amino acid
-fn is_standard_amino_acid(name: &str) -> bool {
-    const AMINO_ACIDS: &[&str] = &[
-        "ALA", "ARG", "ASN", "ASP", "CYS", "GLN", "GLU", "GLY", "HIS", "ILE", "LEU", "LYS", "MET",
-        "PHE", "PRO", "SER", "THR", "TRP", "TYR", "VAL", "SEC", "PYL",
-    ];
-    AMINO_ACIDS.contains(&name)
 }
 
 #[cfg(test)]
@@ -649,6 +640,23 @@ mod tests {
         assert!(structure.binding_site("ATP", 5.0).is_none());
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn make_hetatm(
+        chain: &str,
+        resid: i32,
+        res_name: &str,
+        name: &str,
+        element: &str,
+        x: f64,
+        y: f64,
+        z: f64,
+    ) -> Atom {
+        Atom {
+            is_hetatm: true,
+            ..make_atom(chain, resid, res_name, name, element, x, y, z)
+        }
+    }
+
     #[test]
     fn test_binding_site_detection() {
         let mut structure = PdbStructure::new();
@@ -664,10 +672,10 @@ mod tests {
             .atoms
             .push(make_atom("A", 3, "VAL", "CA", "C", 20.0, 0.0, 0.0)); // Far away
 
-        // Add ligand atom close to residue 1
+        // Add ligand atom close to residue 1 (must be HETATM)
         structure
             .atoms
-            .push(make_atom("A", 100, "ATP", "C1", "C", 2.0, 0.0, 0.0));
+            .push(make_hetatm("A", 100, "ATP", "C1", "C", 2.0, 0.0, 0.0));
 
         let site = structure.binding_site("ATP", 5.0);
         assert!(site.is_some());

--- a/src/descriptors/interactions.rs
+++ b/src/descriptors/interactions.rs
@@ -35,9 +35,9 @@
 //! }
 //! ```
 
+use crate::PdbStructure;
 use crate::classify::{is_standard_amino_acid, is_water};
 use crate::records::Atom;
-use crate::PdbStructure;
 use std::collections::{HashMap, HashSet};
 
 /// Type alias for residue contact tracking: (min_distance, num_contacts, residue_name)

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -43,35 +43,11 @@ pub mod selection;
 // The cleaning and extraction modules extend PdbStructure with impl blocks.
 // Selection module is public for accessing SelectionError and other types.
 
-/// Standard amino acid residue names (3-letter codes).
-pub const STANDARD_AMINO_ACIDS: &[&str] = &[
-    "ALA", "ARG", "ASN", "ASP", "CYS", "GLN", "GLU", "GLY", "HIS", "ILE", "LEU", "LYS", "MET",
-    "PHE", "PRO", "SER", "THR", "TRP", "TYR", "VAL",
-];
-
-/// Standard nucleotide residue names.
-pub const STANDARD_NUCLEOTIDES: &[&str] = &[
-    "A", "C", "G", "U", // RNA
-    "DA", "DC", "DG", "DT", // DNA
-];
-
-/// Check if a residue name is a standard amino acid.
-#[inline]
-pub fn is_standard_amino_acid(residue_name: &str) -> bool {
-    STANDARD_AMINO_ACIDS.contains(&residue_name.trim())
-}
-
-/// Check if a residue name is a standard nucleotide.
-#[inline]
-pub fn is_standard_nucleotide(residue_name: &str) -> bool {
-    STANDARD_NUCLEOTIDES.contains(&residue_name.trim())
-}
-
-/// Check if a residue name is a standard biological residue (amino acid or nucleotide).
-#[inline]
-pub fn is_standard_residue(residue_name: &str) -> bool {
-    is_standard_amino_acid(residue_name) || is_standard_nucleotide(residue_name)
-}
+// Re-export classification constants and functions from the canonical source.
+pub use crate::classify::{
+    is_standard_amino_acid, is_standard_nucleotide, is_standard_residue, STANDARD_AMINO_ACIDS,
+    STANDARD_NUCLEOTIDES,
+};
 
 #[cfg(test)]
 mod tests {

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -45,8 +45,8 @@ pub mod selection;
 
 // Re-export classification constants and functions from the canonical source.
 pub use crate::classify::{
-    is_standard_amino_acid, is_standard_nucleotide, is_standard_residue, STANDARD_AMINO_ACIDS,
-    STANDARD_NUCLEOTIDES,
+    STANDARD_AMINO_ACIDS, STANDARD_NUCLEOTIDES, is_standard_amino_acid, is_standard_nucleotide,
+    is_standard_residue,
 };
 
 #[cfg(test)]

--- a/src/filter/selection/evaluator.rs
+++ b/src/filter/selection/evaluator.rs
@@ -1,6 +1,6 @@
 //! Evaluator for selection expressions against atoms.
 
-use crate::filter::{is_standard_amino_acid, is_standard_nucleotide};
+use crate::classify::{is_standard_amino_acid, is_standard_nucleotide, is_water};
 use crate::records::Atom;
 
 use super::ast::{ComparisonOp, SelectionExpr};
@@ -44,10 +44,7 @@ pub fn evaluate(expr: &SelectionExpr, atom: &Atom) -> bool {
 
         SelectionExpr::Nucleic => is_standard_nucleotide(&atom.residue_name),
 
-        SelectionExpr::Water => {
-            let resname = atom.residue_name.trim().to_uppercase();
-            resname == "HOH" || resname == "WAT" || resname == "TIP3" || resname == "TIP"
-        }
+        SelectionExpr::Water => is_water(&atom.residue_name),
 
         SelectionExpr::Hetero => {
             // HETATM records are non-standard residues

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,7 @@
 //! ```
 
 // Module exports
+pub mod classify;
 pub mod core;
 pub mod error;
 pub mod guide;

--- a/src/ligand_quality/mod.rs
+++ b/src/ligand_quality/mod.rs
@@ -102,7 +102,8 @@ pub const VOLUME_VDW_SCALING: f64 = 0.8;
 pub const VOLUME_GRID_SPACING: f64 = 0.5;
 
 /// Standard water residue names to exclude from ligand checks.
-pub const WATER_RESIDUES: [&str; 4] = ["HOH", "WAT", "H2O", "DOD"];
+/// Re-exported from [`crate::classify::WATER_RESIDUES`] for backwards compatibility.
+pub use crate::classify::WATER_RESIDUES;
 
 impl PdbStructure {
     /// Assess the pose quality of a specific ligand.
@@ -211,7 +212,7 @@ impl PdbStructure {
     ///
     /// `true` if the residue name is a known water identifier.
     pub fn is_water_residue(residue_name: &str) -> bool {
-        WATER_RESIDUES.contains(&residue_name)
+        crate::classify::is_water(residue_name)
     }
 }
 

--- a/src/quality/mod.rs
+++ b/src/quality/mod.rs
@@ -209,23 +209,10 @@ impl PdbStructure {
     ///
     /// `true` if any non-standard residues are present.
     pub fn has_hetatm(&self) -> bool {
-        // Check if any residue is not a standard amino acid or nucleotide
-        #[cfg(feature = "filter")]
-        {
-            use crate::filter::is_standard_residue;
-            self.atoms
-                .iter()
-                .any(|atom| !is_standard_residue(&atom.residue_name))
-        }
-
-        #[cfg(not(feature = "filter"))]
-        {
-            // Fallback: check for common HETATM residue names
-            const NON_STANDARD: &[&str] = &["HOH", "WAT", "DOD", "H2O", "TIP"];
-            self.atoms
-                .iter()
-                .any(|atom| NON_STANDARD.contains(&atom.residue_name.trim()))
-        }
+        use crate::classify::is_standard_residue;
+        self.atoms
+            .iter()
+            .any(|atom| !is_standard_residue(&atom.residue_name))
     }
 
     /// Check if the structure contains hydrogen atoms.


### PR DESCRIPTION
## Summary

- Add `src/classify.rs` — canonical classification constants and helper functions for water, protein, nucleic acid, ligand, and ion identification
- Fix 4 bugs: inconsistent water residue lists across modules, duplicate `is_standard_amino_acid` with conflicting definitions, `binding_site()` treating protein residues as ligands, and `quality::has_hetatm()` requiring the `filter` feature
- Replace local definitions in filter, quality, ligand_quality, descriptors, and selection modules with re-exports from classify
- Update Python binding docstrings for water selection keywords

## Bugs fixed

| Bug | Fix |
|-----|-----|
| 4 different water residue lists across modules | Unified `WATER_RESIDUES` in classify (HOH, WAT, H2O, DOD, TIP, TIP3) |
| `binding_site("ALA", 5.0)` treats protein ALA as ligand | Added `is_hetatm` guard on ligand atom filtering |
| Duplicate `is_standard_amino_acid` (20 vs 22 AAs) | Single canonical definition (20 standard AAs) |
| `quality::has_hetatm()` fallback when `filter` feature disabled | Uses `classify::is_standard_residue()` (always available, no feature gate) |

## Test plan

- [x] `cargo test --all-features` — 769 tests pass (0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo doc --no-deps --all-features` — builds
- [x] Python bindings build and smoke tests pass
- [x] `cargo test --features quality` — quality module works without filter feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)